### PR TITLE
Seperate custom interfaces branch 

### DIFF
--- a/src/custom_interfaces/srv/DetectObjects.srv
+++ b/src/custom_interfaces/srv/DetectObjects.srv
@@ -1,6 +1,7 @@
 # DetectObjects.srv
 
-# Request: No input required
+# Request: Which camera for the service to read from: (front, rear, top, bottom)
+string camera_id
 ---
 
 # Response: Detected object names, positions, and confidence scores


### PR DESCRIPTION
Seperate branch to keep all custom interfaces in one place. when sourcing multiple packages, the last package wins and the wrong .srv or .msg objects are used

Changes to DetectObjects: added a request field. The service client can now request which camera topic the service should perform object detection on, each camera topic corresponds to a set ID. This is useful when writing launch files so you don't have to worry about which topics exactly are being published to. 

Current possible camera_id's (mostly as placeholder) : 'front', 'rear', 'top', 'bottom'